### PR TITLE
Fix PremiseField 'add_filter' attribute does not allow object method call

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ $defaults = array(
 	 */
 	'label'      => '',      // Wraps label element around field. uses id for for attribute if id not empty
 	'tooltip'    => '',      // Adds a tooltip to field
-	'add_filter' => '',      // Add a filter to this field. Read documentation for list of filters
+	'add_filter' => array(), // Add filter(s) to this field. Read documentation for list of filters
 	'context'    => '',      // Used to let Premise know where to retrieve values from ( post, user )
 	/**
 	 * Normal Parameters

--- a/model/model-premise-field.php
+++ b/model/model-premise-field.php
@@ -327,9 +327,9 @@ class PremiseField {
 		if ( ! empty( $this->field['add_filter'] )
 			&& is_array( $this->field['add_filter'] ) ) {
 
-			add_filter( $filter[0], $filter[1] );
+			add_filter( $this->field['add_filter'][0], $this->field['add_filter'][1] );
 
-			array_push( $this->filters_used, $filter[0] );
+			array_push( $this->filters_used, $this->field['add_filter'][0] );
 		}
 
 		if ( 'fa_icon' == $this->type ) {

--- a/model/model-premise-field.php
+++ b/model/model-premise-field.php
@@ -47,7 +47,7 @@ class PremiseField {
 		 */
 		'label'      => '',      // Wraps label element around field. uses id for for attribute if id not empty
 		'tooltip'    => '',      // Adds a tooltip and tooltip functionality to field
-		'add_filter' => '',      // Add a filter to this field. Read documentation for list of filters
+		'add_filter' => array(), // Add a filter to this field. Read documentation for list of filters
 		'context'    => '',      // Used to let Premise know where to retrieve values from ( post, user )
 		/**
 		 * Normal Parameters
@@ -317,16 +317,15 @@ class PremiseField {
 	 * This has to run first to make sure that our filters get hooked before they are called.
 	 * Unsets the filter argument at the end to avoid conflicts when printing attributes on field.
 	 *
-	 * Filters are passed strings containing the name of the filter and the function to call separated
-	 * by a ':'. i.e. premise_field_html_after_wrapper:function_to_call
+	 * Filters are passed arrays containing the name of the filter and the function to call separated
+	 * @example 'add_filter' => array( 'premise_field_input', array( $this, 'my_field_input' ) )
 	 *
 	 * @since 1.2 
 	 */
 	protected function add_filters() {
 		
-		if ( ! empty( $this->field['add_filter'] ) && strpos( $this->field['add_filter'], ':' ) ) {
-
-			$filter = explode( ':', $this->field['add_filter'] );
+		if ( ! empty( $this->field['add_filter'] )
+			&& is_array( $this->field['add_filter'] ) ) {
 
 			add_filter( $filter[0], $filter[1] );
 

--- a/model/model-premise-field.php
+++ b/model/model-premise-field.php
@@ -47,7 +47,7 @@ class PremiseField {
 		 */
 		'label'      => '',      // Wraps label element around field. uses id for for attribute if id not empty
 		'tooltip'    => '',      // Adds a tooltip and tooltip functionality to field
-		'add_filter' => array(), // Add a filter to this field. Read documentation for list of filters
+		'add_filter' => array(), // Add filter(s) to this field. Read documentation for list of filters
 		'context'    => '',      // Used to let Premise know where to retrieve values from ( post, user )
 		/**
 		 * Normal Parameters
@@ -318,7 +318,13 @@ class PremiseField {
 	 * Unsets the filter argument at the end to avoid conflicts when printing attributes on field.
 	 *
 	 * Filters are passed arrays containing the name of the filter and the function to call separated
+	 *
 	 * @example 'add_filter' => array( 'premise_field_input', array( $this, 'my_field_input' ) )
+	 *
+	 * @example 'add_filter' => array(
+	 *              array( 'premise_field_input', array( $this, 'my_field_input' ) ), // Filter 1
+	 *              array( 'premise_field_input', array( $this, 'my_field_input2' ) ), // Filter 2
+	 *          )
 	 *
 	 * @since 1.2 
 	 */
@@ -327,9 +333,23 @@ class PremiseField {
 		if ( ! empty( $this->field['add_filter'] )
 			&& is_array( $this->field['add_filter'] ) ) {
 
-			add_filter( $this->field['add_filter'][0], $this->field['add_filter'][1] );
+			// Array of arrays (multiple filters)
+			if ( is_array( $this->field['add_filter'][0] ) )
+			{
+				foreach( $this->field['add_filter'] as $filter ) {
 
-			array_push( $this->filters_used, $this->field['add_filter'][0] );
+					add_filter( $filter[0], $filter[1] );
+
+					array_push( $this->filters_used, $filter[0] );
+				}
+			}
+			// 1 filter
+			else
+			{
+				add_filter( $this->field['add_filter'][0], $this->field['add_filter'][1] );
+
+				array_push( $this->filters_used, $this->field['add_filter'][0] );
+			}
 		}
 
 		if ( 'fa_icon' == $this->type ) {


### PR DESCRIPTION
Update: enable multiple filters (array of arrays)

The 'add_filter' option of a Premise Field does not allow object method calls whereas the built in WP add_filter() function does, for example:

``` php
add_filter( 'filter', array( $this, 'method' ) );
```

See https://github.com/PremiseWP/Premise-WP/blob/master/model/model-premise-field.php#L325

The following commit allows this.
